### PR TITLE
Fix typo in test DisplayName

### DIFF
--- a/app/src/test/kotlin/me/golf/app/service/domain/order/OrderServiceTest.kt
+++ b/app/src/test/kotlin/me/golf/app/service/domain/order/OrderServiceTest.kt
@@ -44,7 +44,7 @@ class OrderServiceTest {
     }
 
     @Test
-    @DisplayName("선점이 안되어있거나 이미 팔린 티켓이 아나라면 티켓을 구매할 수 있습니다.")
+    @DisplayName("선점이 안되어있거나 이미 팔린 티켓이 아니라면 티켓을 구매할 수 있습니다.")
     fun test1() {
         // given
         val tickets = listOf(TicketFactory.createTicket(id = 1, status = TicketStatus.AVAILABLE))


### PR DESCRIPTION
## Summary
- correct a typo in `OrderServiceTest` display name

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6850b13600ac8331aa39ebfc6228c3aa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - 테스트 메서드의 표시 이름 오타를 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->