### PR TITLE
fix. payment logic Refactoring

### DIFF
--- a/app/src/main/kotlin/me/golf/app/service/domain/order/CheckoutService.kt
+++ b/app/src/main/kotlin/me/golf/app/service/domain/order/CheckoutService.kt
@@ -1,5 +1,6 @@
 package me.golf.app.service.domain.order
 
+import me.golf.app.service.domain.stock.listener.dto.CheckoutSuccessEvent
 import me.golf.app.service.domain.stock.listener.dto.OrderFailEvent
 import me.golf.core.model.domain.order.Order
 import me.golf.core.model.domain.payment.Payment
@@ -29,54 +30,61 @@ class CheckoutService(
 
     @Transactional
     override fun checkout(message: CheckoutRequestMessage): CheckoutCompleteResponseMessage {
-        eventPublisher.publishEvent(OrderFailEvent(message.orderId))
+        val order = orderRepository.findByIdAndUserId(message.orderId, message.userId)
+        val tickets = ticketRepository.findAllByOrderId(order.orderItem.map { it.itemId })
 
-        val order: Order = orderRepository.findByIdAndUserId(message.orderId, message.userId)
-        val tickets: List<Ticket> = ticketRepository.findAllByOrderId(order.orderItem.map { it.itemId })
+        kotlin.runCatching { validateTickets(tickets, message) }
+            .onFailure { publishFailureEventAndThrow(message, it) }
 
-        validationTickets(tickets, message)
-
-        // 선점 한 적이 있는지 확인
-        if (stockRepository.existsReserveByOrderId(message.orderId)) {
-            stockRepository.updateTtl(message.orderId)
-        } else {
-            val reserveStock = stockRepository.reserveStock(message.orderId, tickets.map { it.id })
-
-            if (!reserveStock) {
-                throw IllegalArgumentException("상품 선점에 실패했습니다.")
-            }
-        }
-
-        order.payment?.let { return CheckoutCompleteResponseMessage(order.orderId, order.amount, it.idempotentKey) }
-
-        // create payment
-        val payment = createPayment(order, message.paymentMethod)
-        paymentRepository.save(payment, order)
-
+        eventPublisher.publishEvent(CheckoutSuccessEvent(order.orderId, tickets.map { it.id }))
+        
+        val payment = order.payment ?: createAndSaveNewPayment(order, message.paymentMethod)
+        
         return CheckoutCompleteResponseMessage(order.orderId, order.amount, payment.idempotentKey)
     }
 
-    private fun validationTickets(tickets: List<Ticket>, message: CheckoutRequestMessage) {
+    private fun validateTickets(tickets: List<Ticket>, message: CheckoutRequestMessage) {
+        validateTicketsExist(tickets)
+        validateTicketsPurchasable(tickets)
+        validateTicketsNotAlreadyReserved(tickets.map { it.id }, message.orderId)
+    }
+
+    private fun validateTicketsExist(tickets: List<Ticket>) {
         if (tickets.isEmpty()) {
             throw IllegalArgumentException("주문 티켓이 존재하지 않습니다.")
         }
+    }
 
+    private fun validateTicketsPurchasable(tickets: List<Ticket>) {
         if (tickets.any { it.isNonPurchase() }) {
             throw IllegalArgumentException("구매할 수 없는 주문 상태입니다.")
         }
+    }
 
-        if (stockRepository.alreadyReserveByTicketIds(message.orderId, tickets.map { it.id })) {
+    private fun validateTicketsNotAlreadyReserved(ticketIds: List<Long>, orderId: String) {
+        if (stockRepository.alreadyReserveByTicketIds(orderId, ticketIds)) {
             throw IllegalArgumentException("이미 선점 중인 상품입니다.")
         }
     }
 
-    private fun createPayment(order: Order, paymentMethod: PaymentMethod) =
-        Payment.create(
-            amount = order.amount,
-            userId = order.userId,
+    private fun publishFailureEventAndThrow(message: CheckoutRequestMessage, exception: Throwable): Nothing {
+        eventPublisher.publishEvent(OrderFailEvent(message.orderId))
+        throw exception
+    }
+
+    private fun createAndSaveNewPayment(order: Order, paymentMethod: PaymentMethod): Payment {
+        val payment = order.createPayment(paymentMethod)
+        return paymentRepository.save(payment, order)
+    }
+
+    private fun Order.createPayment(paymentMethod: PaymentMethod): Payment {
+        return Payment.create(
+            amount = this.amount,
+            userId = this.userId,
             idempotentKey = "",
             paymentMethod = paymentMethod,
             paymentStatus = PaymentStatus.PENDING,
             paymentDate = LocalDateTime.now(),
         )
+    }
 }

--- a/app/src/main/kotlin/me/golf/app/service/domain/payment/PaymentService.kt
+++ b/app/src/main/kotlin/me/golf/app/service/domain/payment/PaymentService.kt
@@ -5,7 +5,9 @@ import me.golf.app.service.domain.payment.listener.dto.LedgerEventMessage
 import me.golf.app.service.domain.payment.listener.dto.WalletEventMessage
 import me.golf.app.service.domain.stock.listener.dto.OrderFailEvent
 import me.golf.app.service.domain.stock.listener.dto.PaymentSuccessEvent
+import me.golf.core.model.domain.order.Order
 import me.golf.core.model.domain.order.OrderState
+import me.golf.core.model.domain.payment.Payment
 import me.golf.core.repository.domain.item.TicketRepository
 import me.golf.core.repository.domain.order.OrderRepository
 import me.golf.core.repository.domain.payment.PaymentRepository
@@ -26,22 +28,32 @@ class PaymentService(
 
     @Transactional
     override fun payment(message: PaymentRequestMessage): PaymentResponseMessage {
-        eventPublisher.publishEvent(OrderFailEvent(message.orderId))
+        publishPaymentFailEvent(message)
 
         val order = orderRepository.findWithPaymentById(message.orderId)
-
         val payment = order.payment ?: throw IllegalArgumentException("payment must not be null")
         val completePayment = paymentRepository.confirm(payment.addIdempotentKey(message.paymentKey), order.orderId)
 
-        TransactionHelper.execute {
-            paymentRepository.update(completePayment, order.orderId)
+        TransactionHelper.execute { paymentPostProcess(completePayment, order) }
+        publishPaymentSuccessEvent(completePayment, order)
 
-            val tickets = ticketRepository.findAllByOrderId(order.orderItem.map { it.itemId })
+        return PaymentResponseMessage(paymentId = completePayment.id!!, paymentDate = completePayment.paymentDate)
+    }
 
-            orderRepository.save(order.changeState(OrderState.SUCCESS))
-            ticketRepository.saveAll(tickets.map { it.purchase() })
-        }
+    private fun publishPaymentFailEvent(message: PaymentRequestMessage) {
+        eventPublisher.publishEvent(OrderFailEvent(message.orderId))
+    }
 
+    private fun paymentPostProcess(completePayment: Payment, order: Order) {
+        paymentRepository.update(completePayment, order.orderId)
+
+        val tickets = ticketRepository.findAllByOrderId(order.orderItem.map { it.itemId })
+
+        orderRepository.save(order.changeState(OrderState.SUCCESS))
+        ticketRepository.saveAll(tickets.map { it.purchase() })
+    }
+
+    private fun publishPaymentSuccessEvent(completePayment: Payment, order: Order) {
         // wallet event 발생
         eventPublisher.publishEvent(WalletEventMessage(completePayment.id!!, order.userId))
 
@@ -50,7 +62,5 @@ class PaymentService(
 
         // 선점 해제 이벤트 발생
         eventPublisher.publishEvent(PaymentSuccessEvent(completePayment.id!!, order.orderId))
-
-        return PaymentResponseMessage(paymentId = completePayment.id!!, paymentDate = completePayment.paymentDate)
     }
 }

--- a/app/src/main/kotlin/me/golf/app/service/domain/stock/listener/StockListener.kt
+++ b/app/src/main/kotlin/me/golf/app/service/domain/stock/listener/StockListener.kt
@@ -1,5 +1,6 @@
 package me.golf.app.service.domain.stock.listener
 
+import me.golf.app.service.domain.stock.listener.dto.CheckoutSuccessEvent
 import me.golf.app.service.domain.stock.listener.dto.OrderCompleteEvent
 import me.golf.app.service.domain.stock.listener.dto.OrderFailEvent
 import me.golf.app.service.domain.stock.listener.dto.PaymentSuccessEvent
@@ -27,7 +28,34 @@ class StockListener(
         val result = kotlin.runCatching { stockRepository.reserveStock(orderId = event.orderId, itemIds = event.ticketIds) }
 
         result.onFailure {
-            log.error("주문 ID : {}, 선점 실패 사유 : {}", event.orderId, it.message)
+            log.info("주문 ID : {}, 선점 실패 사유 : {}", event.orderId, it.message)
+        }
+    }
+
+    @Async
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun handleStockReservation(event: CheckoutSuccessEvent) {
+        log.info("선점 정보 갱신 시작 : 주문 ID : {}", event.orderId)
+
+        kotlin.runCatching { updateStockReservationProcess(event) }
+            .onFailure { log.info("선점 실패 : {}", event.orderId) }
+    }
+
+    private fun updateStockReservationProcess(event: CheckoutSuccessEvent) {
+        if (stockRepository.existsReserveByOrderId(event.orderId)) {
+            stockRepository.updateTtl(event.orderId)
+            return
+        }
+
+        retryReserveStock(event.orderId, event.ticketIds)
+    }
+
+    private fun retryReserveStock(orderId: String, ticketIds: List<Long>) {
+        val reserveResult = stockRepository.reserveStock(orderId, ticketIds)
+
+        if (!reserveResult) {
+            throw IllegalArgumentException("상품 선점에 실패했습니다.")
         }
     }
 
@@ -39,7 +67,7 @@ class StockListener(
         val result = kotlin.runCatching { stockRepository.cancelReserve(event.orderId) }
 
         result.onFailure {
-            log.error("주문 ID : {} 선점 종료 실패 사유 : {}", event.orderId, it.message)
+            log.info("주문 ID : {} 선점 종료 실패 사유 : {}", event.orderId, it.message)
         }
     }
 
@@ -51,7 +79,7 @@ class StockListener(
         val result = kotlin.runCatching { stockRepository.cancelReserve(event.orderId) }
 
         result.onFailure {
-            log.error("주문 ID : {} 선점 실패 사유: {}", event.orderId, it.message)
+            log.info("주문 ID : {} 선점 실패 사유: {}", event.orderId, it.message)
         }
     }
 }

--- a/app/src/main/kotlin/me/golf/app/service/domain/stock/listener/StockListener.kt
+++ b/app/src/main/kotlin/me/golf/app/service/domain/stock/listener/StockListener.kt
@@ -55,6 +55,7 @@ class StockListener(
         val reserveResult = stockRepository.reserveStock(orderId, ticketIds)
 
         if (!reserveResult) {
+            log.error("상품 선점 실패 : 주문 번호: {}", orderId)
             throw IllegalArgumentException("상품 선점에 실패했습니다.")
         }
     }

--- a/app/src/main/kotlin/me/golf/app/service/domain/stock/listener/dto/CheckoutSuccessEvent.kt
+++ b/app/src/main/kotlin/me/golf/app/service/domain/stock/listener/dto/CheckoutSuccessEvent.kt
@@ -1,0 +1,6 @@
+package me.golf.app.service.domain.stock.listener.dto
+
+data class CheckoutSuccessEvent(
+    val orderId: String,
+    val ticketIds: List<Long>
+)

--- a/infra/src/main/kotlin/me/golf/infra/repository/domain/stock/StockRepositoryImpl.kt
+++ b/infra/src/main/kotlin/me/golf/infra/repository/domain/stock/StockRepositoryImpl.kt
@@ -10,7 +10,7 @@ class StockRepositoryImpl(
 ): StockRepository {
 
     override fun reserveStock(orderId: String, itemIds: Collection<Long>): Boolean {
-        return stockDao.saveOrderReserveInfo(orderId, itemIds, 20)
+        return stockDao.saveOrderReserveInfo(orderId, itemIds, 5)
     }
 
     override fun alreadyReserveByTicketIds(orderId: String, ticketIds: List<Long>): Boolean {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 결제 성공 시 주문 ID와 티켓 ID를 포함한 CheckoutSuccessEvent 이벤트가 도입되었습니다.
  * 체크아웃 성공 후 재고 예약을 비동기 및 별도 트랜잭션으로 처리하는 기능이 추가되었습니다.

* **버그 수정**
  * 결제 및 체크아웃 과정에서 예외 발생 시 실패 이벤트가 정확히 발행되도록 개선되었습니다.
  * 재고 예약 실패 로그가 에러에서 정보 수준으로 조정되었습니다.

* **리팩터링**
  * 결제 및 체크아웃 서비스의 내부 로직이 명확하게 분리되어 유지보수가 용이해졌습니다.
  * 재고 예약 처리 로직이 이벤트 기반으로 전환되었습니다.

* **기타**
  * 티켓 예약 시간(예약 TTL)이 20분에서 5분으로 단축되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->